### PR TITLE
Require composer-plugin-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "autoload": {
         "psr-0": { "": "src/"}
     },
+    "require": {
+        "composer-plugin-api": "1.0.0"
+    },    
     "require-dev": {
         "composer/composer": "1.*"
     },


### PR DESCRIPTION
This is needed to make the plugin work. 

See https://getcomposer.org/doc/articles/plugins.md#plugin-package.
