### PR TITLE
Allow patches to be defined in the root package

### DIFF
--- a/src/Netresearch/Composer/Patches/Plugin.php
+++ b/src/Netresearch/Composer/Patches/Plugin.php
@@ -220,6 +220,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			$patchSets[$initialPackage->getName()] = array($extra['patches'], $packages);
 		}
 
+		// Patches may also be defined in the root package.
+		$rootPackage = $this->composer->getPackage();
+		$extra = $rootPackage->getExtra();
+		if (!empty($extra['patches'])) {
+		  foreach (array_keys($extra['patches']) as $packageName) {
+		      $packages = $this->composer->getRepositoryManager()->getLocalRepository()->findPackages($packageName);
+		      $patchSets[$rootPackage->getName()] = array($extra['patches'], $packages);
+		  }
+		}
+
 		$patchesAndPackages = array();
 		foreach ($patchSets as $sourceName => $patchConfAndPackages) {
 			$patchSet = new PatchSet($patchConfAndPackages[0], $this->downloader);


### PR DESCRIPTION
Digging through this project I found that is does not seem to be possible to define a patch for a package in the root package.

This change allows for such:

``` json
    "extra": {
      "patches": {
        "vendor/name": {
          "1.2.3": [
            {
              "url": "https://my-domain.com/path/to/my.patch"
            }
          ]
        }
      }
    }
```
