### PR TITLE
Introduce maximum offset parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "netresearch/composer-patches-plugin",
+    "name": "legolasbo/composer-patches-plugin",
     "type": "composer-plugin",
     "license": "GPL-2.0",
     "description": "Composer patches plugin",
@@ -28,5 +28,6 @@
         "branch-alias": {
             "dev-master": "1.2.x-dev"
         }
-    }
+    },
+    "replace": {"netresearch/composer-patches-plugin": "^1"}
 }


### PR DESCRIPTION
On several occasions we've encountered an issue where a patch gets applied every time this plugin is invoked. This is caused because the native patch command does not properly detect that a patch was already applied and applies it again with a (increasingly larger) offset.

https://www.drupal.org/node/2727279 has two patches that demonstrate this problem. See patch definition below:
`{
  "type": "metapackage",
  "name": "example/name",
  "require": {
    "netresearch/composer-patches-plugin": "~1.0"
  },
  "extra": {
    "patches": {
      "drupal/composer_autoloader": {
        "7.1.1":  [
          {
            "title": "[BUGFIX] Composer autoloader is not available during access callbacks called trough the menu routing system. See https://www.drupal.org/node/2727279.",
            "url": "https://www.drupal.org/files/issues/autoloader_is_not-2727279-3.patch"
          }
        ]
      }
    }
  }
}
`

This pull request introduces a maximum_offset parameter which can be used to prevent the patch from being applied twice. See example below:
`"drupal/composer_autoloader": {
        "7.1.1":  [
          {
            "title": "[BUGFIX] Composer autoloader is not available during access callbacks called trough the menu routing system. See https://www.drupal.org/node/2727279.",
            "url": "https://www.drupal.org/files/issues/autoloader_is_not-2727279-3.patch",
            "maximum_offset": 30
          }
        ]
      }`
