### PR TITLE
Updated patch exec location check to attempt fallback to global "patch"

### DIFF
--- a/src/Netresearch/Composer/Patches/Patch.php
+++ b/src/Netresearch/Composer/Patches/Patch.php
@@ -197,6 +197,7 @@ class Patch {
 		if (!$patchCommand) {
 			$exitCode = $output = null;
 			$patchCommand = exec('which patch', $output, $exitCode);
+			$patchCommand = $exitCode === 0 ? realpath($patchCommand) : $patchCommand;
 			if (0 !== $exitCode || !is_executable($patchCommand)) {
 				throw new Exception("Cannot find the 'patch' executable command - use your o/s package manager like 'sudo yum install patch'");
 			}

--- a/src/Netresearch/Composer/Patches/Patch.php
+++ b/src/Netresearch/Composer/Patches/Patch.php
@@ -197,9 +197,13 @@ class Patch {
 		if (!$patchCommand) {
 			$exitCode = $output = null;
 			$patchCommand = exec('which patch', $output, $exitCode);
-			$patchCommand = $exitCode === 0 ? realpath($patchCommand) : $patchCommand;
 			if (0 !== $exitCode || !is_executable($patchCommand)) {
-				throw new Exception("Cannot find the 'patch' executable command - use your o/s package manager like 'sudo yum install patch'");
+				// See if patch is in path.
+				$exitCode = $output = null;
+				exec('patch -v', $output, $exitCode);
+				if (0 !== $exitCode) {
+				    throw new Exception("Cannot find the 'patch' executable command - use your o/s package manager like 'sudo yum install patch'");
+			    }
 			}
 		}
 		return $patchCommand;


### PR DESCRIPTION
fixes it failing on windows if patch is actually available in the `PATH`
