### PR TITLE
Fix local patches for Composer 2.3.0

### DIFF
--- a/src/Netresearch/Composer/Patches/Downloader/Composer.php
+++ b/src/Netresearch/Composer/Patches/Downloader/Composer.php
@@ -54,7 +54,13 @@ class Composer implements DownloaderInterface
      */
     public function getContents($url)
     {
-        return $this->remoteFileSystem->getContents($this->getOriginUrl($url), $url, false);
+        $originUrl = $this->getOriginUrl($url);
+
+        if (is_null($originUrl)) {
+            return file_get_contents($url);
+        }
+
+        return $this->remoteFileSystem->getContents($originUrl, $url, false);
     }
 
     /**


### PR DESCRIPTION
We define our patches using relative paths to local files for `url`:

https://github.com/art-institute-of-chicago/data-hub-foundation/blob/adbbb46b2e439c157dc581119aa2085fe0dd8a6c/composer.json

This was working great until recently. Our deployments broke because we upgraded one of our servers from Composer 2.2.9 to Composer 2.3.4. We started seeing this error:

```
In RemoteFilesystem.php line 124:

  [TypeError]
  Composer\Util\RemoteFilesystem::getContents(): Argument #1 ($originUrl) must be of type string, null given, called in /path/to/vendor/netresearch/composer-patches-plugin/src/Netresearch/Composer/Patches/Downloader/Composer.php on line 57


Exception trace:
  at phar:///usr/local/bin/composer/src/Composer/Util/RemoteFilesystem.php:124
 Composer\Util\RemoteFilesystem->getContents() at /path/to/vendor/netresearch/composer-patches-plugin/src/Netresearch/Composer/Patches/Downloader/Composer.php:57
 Netresearch\Composer\Patches\Downloader\Composer->getContents() at /path/to/vendor/netresearch/composer-patches-plugin/src/Netresearch/Composer/Patches/Patch.php:124
 Netresearch\Composer\Patches\Patch->read() at /path/to/vendor/netresearch/composer-patches-plugin/src/Netresearch/Composer/Patches/Patch.php:74

 <snip>
```

We traced the problem to this commit in the Composer codebase:

https://github.com/composer/composer/commit/6da38f83a0d5acc71793f337b525fa2faff9468e

I figure that checking if `$originUrl` is `null` and if so doing `file_get_contents($url)` is the path of least resistance.